### PR TITLE
Commented out parameters used by consumers

### DIFF
--- a/pandacommon/kafkapublisher/KafkaPublisher.py
+++ b/pandacommon/kafkapublisher/KafkaPublisher.py
@@ -16,12 +16,12 @@ class KafkaPublisher:
         kafka_config = common_config.get('kafka')
         self.producer = Producer({
                 'bootstrap.servers': self.get_bootstrap_servers(kafka_config['kafka_cluster'], kafka_config['kafka_cluster_domain']),
-                'group.id': kafka_config['group_id'],
+                #'group.id': kafka_config['group_id'],
                 'ssl.ca.location': kafka_config['cacerts'],
                 'security.protocol': 'SASL_SSL',
                 'sasl.kerberos.keytab': kafka_config['keytab'],
-                'auto.offset.reset': 'latest',
-                'enable.auto.offset.store': True,
+                #'auto.offset.reset': 'latest',
+                #'enable.auto.offset.store': True,
                 'sasl.kerberos.principal': kafka_config['principal'],
                 'log_level': 0
         })


### PR DESCRIPTION
Commented out the following parameters due to the warning below:

group.id, enable.auto.offset.store, auto.offset.reset

%4|1688563037.188|CONFWARN|rdkafka#producer-1| [thrd:app]: Configuration property group.id is a consumer property and will be ignored by this producer instance
%4|1688563037.189|CONFWARN|rdkafka#producer-1| [thrd:app]: Configuration property enable.auto.offset.store is a consumer property and will be ignored by this producer instance
%4|1688563037.189|CONFWARN|rdkafka#producer-1| [thrd:app]: Configuration property auto.offset.reset is a consumer property and will be ignored by this producer instance