### PR TITLE
Avoid crashing with nested dicts like in the 'config' part of panda server

### DIFF
--- a/pandacommon/liveconfigparser/LiveConfigParser.py
+++ b/pandacommon/liveconfigparser/LiveConfigParser.py
@@ -76,6 +76,11 @@ def expand_values(target, values_dict):
     for tmp_key in values_dict:
         tmp_val = values_dict[tmp_key]
 
+        # skip non-string values early
+        if not isinstance(tmp_val, str):
+            target.__dict__[tmp_key] = tmp_val
+            continue
+
         # env variable like $VAR, ${VAR}, ${{VAR}}
         match_object = re.search(r"^\$\{*(\w+)\}*$", tmp_val)
         if match_object and match_object.group(1) in os.environ:


### PR DESCRIPTION
Avoid crashing with nested dicts like in the 'config' part of panda server. Makes sure only strings go into re.search() and re.match() — avoiding the crash entirely.

```
[root@panda-server-0 init.d]# /etc/rc.d/init.d/httpd-pandasrv start
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/opt/panda/lib/python3.11/site-packages/pandaserver/config/daemon_config.py", line 25, in <module>
    expand_values(tmpSelf, tmpDict)
  File "/opt/panda/lib/python3.11/site-packages/pandacommon/liveconfigparser/LiveConfigParser.py", line 80, in expand_values
    match_object = re.search(r"^\$\{*(\w+)\}*$", tmp_val)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/re/__init__.py", line 176, in search
    return _compile(pattern, flags).search(string)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: expected string or bytes-like object, got 'dict'
```