### PR TITLE
Fix typos in comments and docstrings

### DIFF
--- a/pandacommon/pandamsgbkr/msg_bkr_utils.py
+++ b/pandacommon/pandamsgbkr/msg_bkr_utils.py
@@ -118,7 +118,7 @@ class MsgBuffer:
             return _BUFFER_MAP[key]
 
     def __init__(self, *args, **kwargs):
-        # Do NOT write anything here becuase of singleton
+        # Do NOT write anything here because of singleton
         pass
 
     def size(self):

--- a/pandacommon/pandamsgbkr/msg_processor.py
+++ b/pandacommon/pandamsgbkr/msg_processor.py
@@ -79,7 +79,7 @@ class SimpleMsgProcPluginBase:
     Simple message processor suits following cases:
         - one-out: to create a messages and send them to one queue
         - one-in: to receive messages from one queue and processes the messages
-        - one-in-one-out: to receive messages from one queue, processes the messages to create new messages, and then and send new messages to another queue
+        - one-in-one-out: to receive messages from one queue, processes the messages to create new messages, and then send new messages to another queue
     """
 
     def __init__(self, **params):


### PR DESCRIPTION
## Summary
Fix 2 spelling errors in comments and docstrings:
- `becuase` → `because` (`msg_bkr_utils.py`)
- `and then and send` → `and then send` (`msg_processor.py`)

## Test plan
- [ ] No functional changes — comments and docstrings only