### PR TITLE
Fix AttributeError with stomp.py 9.x in msg_bkr_utils

### DIFF
--- a/pandacommon/pandamsgbkr/msg_bkr_utils.py
+++ b/pandacommon/pandamsgbkr/msg_bkr_utils.py
@@ -1,6 +1,7 @@
 import collections
 import copy
 import datetime
+import logging
 import os
 import random
 import re
@@ -21,7 +22,7 @@ base_logger = logger_utils.setup_logger("msg_bkr_utils")
 # adjust stomp logger
 stomp_log_level = "INFO"
 panda_stomp_logger = logger_utils.setup_logger("stomp.py")
-stomp_logger = stomp.logging.__logger
+stomp_logger = logging.getLogger("stomp")
 for handler in stomp_logger.handlers.copy():
     handler.close()
     stomp_logger.removeHandler(handler)


### PR DESCRIPTION
stomp.py 9.x removed the `stomp.logging.__logger` attribute, causing an `AttributeError` at import time:

```
AttributeError: module 'stomp' has no attribute 'logging'
```

This crashes the JediMaster process on startup, preventing panda-jedi from running at all. Observed on the ATLAS testbed with stomp.py 9.0.0 installed.

Replace with `logging.getLogger("stomp")` which works across all stomp.py versions.